### PR TITLE
feat: update dashboard for ai-scheduler schema changes

### DIFF
--- a/backend/app/collectors/scheduler_collector.py
+++ b/backend/app/collectors/scheduler_collector.py
@@ -29,10 +29,31 @@ async def collect(db_path: str = DEFAULT_DB_PATH) -> dict[str, Any]:
                 "FROM runs ORDER BY started_at DESC LIMIT 20"
             )
             rows = await cursor.fetchall()
+            runs = [dict(row) for row in rows]
+
+            # Fetch events for these runs
+            if runs:
+                run_ids = [r["id"] for r in runs]
+                placeholders = ",".join("?" * len(run_ids))
+                event_cursor = await db.execute(
+                    f"SELECT id, run_id, timestamp, event_type, detail "
+                    f"FROM run_events WHERE run_id IN ({placeholders}) "
+                    f"ORDER BY timestamp ASC",
+                    run_ids,
+                )
+                event_rows = await event_cursor.fetchall()
+
+                events_by_run: dict[int, list[dict]] = {r["id"]: [] for r in runs}
+                for evt in event_rows:
+                    evt_dict = dict(evt)
+                    rid = evt_dict.pop("run_id")
+                    if rid in events_by_run:
+                        events_by_run[rid].append(evt_dict)
+
+                for run in runs:
+                    run["events"] = events_by_run[run["id"]]
     except Exception:
         return {"health": "unknown", "runs": []}
-
-    runs = [dict(row) for row in rows]
 
     if runs:
         latest_outcome = runs[0]["outcome"]

--- a/backend/app/collectors/scheduler_collector.py
+++ b/backend/app/collectors/scheduler_collector.py
@@ -32,27 +32,31 @@ async def collect(db_path: str = DEFAULT_DB_PATH) -> dict[str, Any]:
             rows = await cursor.fetchall()
             runs = [dict(row) for row in rows]
 
-            # Fetch events for these runs
-            if runs:
-                run_ids = [r["id"] for r in runs]
-                placeholders = ",".join("?" * len(run_ids))
-                event_cursor = await db.execute(
-                    f"SELECT id, run_id, timestamp, event_type, detail "
-                    f"FROM run_events WHERE run_id IN ({placeholders}) "
-                    f"ORDER BY timestamp ASC",
-                    run_ids,
-                )
-                event_rows = await event_cursor.fetchall()
+            # Fetch events for these runs (separate try so runs survive if table missing)
+            try:
+                if runs:
+                    run_ids = [r["id"] for r in runs]
+                    placeholders = ",".join("?" * len(run_ids))
+                    event_cursor = await db.execute(
+                        f"SELECT id, run_id, timestamp, event_type, detail "
+                        f"FROM run_events WHERE run_id IN ({placeholders}) "
+                        f"ORDER BY timestamp ASC",
+                        run_ids,
+                    )
+                    event_rows = await event_cursor.fetchall()
 
-                events_by_run: dict[int, list[dict]] = {r["id"]: [] for r in runs}
-                for evt in event_rows:
-                    evt_dict = dict(evt)
-                    rid = evt_dict.pop("run_id")
-                    if rid in events_by_run:
-                        events_by_run[rid].append(evt_dict)
+                    events_by_run: dict[int, list[dict]] = {r["id"]: [] for r in runs}
+                    for evt in event_rows:
+                        evt_dict = dict(evt)
+                        rid = evt_dict.pop("run_id")
+                        if rid in events_by_run:
+                            events_by_run[rid].append(evt_dict)
 
+                    for run in runs:
+                        run["events"] = events_by_run[run["id"]]
+            except Exception:
                 for run in runs:
-                    run["events"] = events_by_run[run["id"]]
+                    run["events"] = []
     except Exception:
         return {"health": "unknown", "runs": []}
 

--- a/backend/app/collectors/scheduler_collector.py
+++ b/backend/app/collectors/scheduler_collector.py
@@ -1,3 +1,4 @@
+import json
 import os
 from pathlib import Path
 from typing import Any
@@ -62,3 +63,16 @@ async def collect(db_path: str = DEFAULT_DB_PATH) -> dict[str, Any]:
         health = "unknown"
 
     return {"health": health, "runs": runs}
+
+
+async def get_run_messages(run_id: int, db_path: str = DEFAULT_DB_PATH) -> list[dict] | None:
+    """Fetch agent messages for a specific run. Returns None if NULL, raises ValueError if not found."""
+    uri = f"file:{db_path}?mode=ro"
+    async with aiosqlite.connect(uri, uri=True) as db:
+        cursor = await db.execute("SELECT messages FROM runs WHERE id = ?", (run_id,))
+        row = await cursor.fetchone()
+        if row is None:
+            raise ValueError(f"Run {run_id} not found")
+        if row[0] is None:
+            return None
+        return json.loads(row[0])

--- a/backend/app/collectors/scheduler_collector.py
+++ b/backend/app/collectors/scheduler_collector.py
@@ -25,7 +25,7 @@ async def collect(db_path: str = DEFAULT_DB_PATH) -> dict[str, Any]:
         async with aiosqlite.connect(uri, uri=True) as db:
             db.row_factory = aiosqlite.Row
             cursor = await db.execute(
-                "SELECT id, repo, issue_number, session_type, started_at, ended_at, outcome, pr_number, notes "
+                "SELECT id, repo, issue_number, session_type, started_at, ended_at, outcome, pr_number, notes, validation_reason "
                 "FROM runs ORDER BY started_at DESC LIMIT 20"
             )
             rows = await cursor.fetchall()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,9 +4,12 @@ from contextlib import asynccontextmanager
 from pathlib import Path
 
 from fastapi import FastAPI
+from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
+from starlette.responses import Response
 
 from app.cache import get_cached, run_all_collectors
+from app.collectors.scheduler_collector import get_run_messages
 
 logger = logging.getLogger(__name__)
 
@@ -68,6 +71,19 @@ async def status():
 async def refresh():
     """Trigger immediate re-collection of all data sources."""
     return await run_all_collectors()
+
+
+@app.get("/api/runs/{run_id}/messages")
+async def run_messages(run_id: int):
+    try:
+        messages = await get_run_messages(run_id)
+    except ValueError:
+        return JSONResponse(status_code=404, content={"detail": "Run not found"})
+    except Exception:
+        return JSONResponse(status_code=503, content={"detail": "Database unavailable"})
+    if messages is None:
+        return Response(status_code=204)
+    return messages
 
 
 if STATIC_DIR.is_dir():

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -43,6 +43,8 @@ FAKE_SCHEDULER = {
             "outcome": "completed",
             "pr_number": None,
             "notes": None,
+            "validation_reason": "Plan found in comments",
+            "events": [],
         }
     ],
 }

--- a/backend/tests/test_messages_endpoint.py
+++ b/backend/tests/test_messages_endpoint.py
@@ -1,0 +1,55 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.main import app
+
+
+@pytest.fixture(autouse=True)
+def reset_cache():
+    """Reset cache state before each test."""
+    import app.cache as cache_mod
+    cache_mod._cache = {}
+    cache_mod._last_updated = None
+    yield
+    cache_mod._cache = {}
+    cache_mod._last_updated = None
+
+
+@pytest.mark.asyncio
+async def test_messages_endpoint_returns_json():
+    messages = [{"role": "user", "content": "hello"}]
+    with patch("app.main.get_run_messages", new_callable=AsyncMock, return_value=messages):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.get("/api/runs/1/messages")
+    assert response.status_code == 200
+    assert response.json() == messages
+
+
+@pytest.mark.asyncio
+async def test_messages_endpoint_returns_204_when_null():
+    with patch("app.main.get_run_messages", new_callable=AsyncMock, return_value=None):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.get("/api/runs/1/messages")
+    assert response.status_code == 204
+
+
+@pytest.mark.asyncio
+async def test_messages_endpoint_returns_404_when_not_found():
+    with patch("app.main.get_run_messages", new_callable=AsyncMock, side_effect=ValueError("Run 999 not found")):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.get("/api/runs/999/messages")
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_messages_endpoint_returns_503_on_db_error():
+    with patch("app.main.get_run_messages", new_callable=AsyncMock, side_effect=Exception("DB connection failed")):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.get("/api/runs/1/messages")
+    assert response.status_code == 503

--- a/backend/tests/test_scheduler_collector.py
+++ b/backend/tests/test_scheduler_collector.py
@@ -210,3 +210,40 @@ async def test_collect_validation_reason_null(tmp_path):
     db_path = _create_db(tmp_path, rows)
     result = await collect(db_path=str(db_path))
     assert result["runs"][0]["validation_reason"] is None
+
+
+# --- run_events ---
+
+
+@pytest.mark.asyncio
+async def test_collect_includes_events_per_run(tmp_path):
+    rows = [
+        (1, "owner/repo", 10, "implementation", "2026-03-20T10:00:00Z", "2026-03-20T10:30:00Z", "completed", 5, None, None),
+        (2, "owner/repo", 11, "planning", "2026-03-21T10:00:00Z", "2026-03-21T10:30:00Z", "completed", None, None, None),
+    ]
+    events = [
+        (1, "2026-03-20T10:00:00Z", "session_started", '{"session_id": "abc"}'),
+        (1, "2026-03-20T10:15:00Z", "pr_found", '{"pr_number": 5}'),
+        (2, "2026-03-21T10:00:00Z", "session_started", None),
+    ]
+    db_path = _create_db(tmp_path, rows, events)
+    result = await collect(db_path=str(db_path))
+
+    # Run 2 (newest) should have 1 event
+    assert len(result["runs"][0]["events"]) == 1
+    assert result["runs"][0]["events"][0]["event_type"] == "session_started"
+
+    # Run 1 should have 2 events, ordered by timestamp
+    assert len(result["runs"][1]["events"]) == 2
+    assert result["runs"][1]["events"][0]["event_type"] == "session_started"
+    assert result["runs"][1]["events"][1]["event_type"] == "pr_found"
+
+
+@pytest.mark.asyncio
+async def test_collect_run_with_no_events_gets_empty_array(tmp_path):
+    rows = [
+        (1, "owner/repo", 10, "planning", "2026-03-20T10:00:00Z", "2026-03-20T10:30:00Z", "completed", None, None, None),
+    ]
+    db_path = _create_db(tmp_path, rows)  # no events
+    result = await collect(db_path=str(db_path))
+    assert result["runs"][0]["events"] == []

--- a/backend/tests/test_scheduler_collector.py
+++ b/backend/tests/test_scheduler_collector.py
@@ -7,7 +7,7 @@ import pytest
 from app.collectors.scheduler_collector import collect
 
 
-def _create_db(tmp_path: Path, rows: list[tuple] | None = None) -> Path:
+def _create_db(tmp_path: Path, rows: list[tuple] | None = None, events: list[tuple] | None = None) -> Path:
     """Create a temporary SQLite DB with the runs table schema."""
     db_path = tmp_path / "history.db"
     conn = sqlite3.connect(str(db_path))
@@ -21,13 +21,30 @@ def _create_db(tmp_path: Path, rows: list[tuple] | None = None) -> Path:
             ended_at TEXT,
             outcome TEXT,
             pr_number INTEGER,
-            notes TEXT
+            notes TEXT,
+            validation_reason TEXT,
+            messages TEXT
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE run_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            run_id INTEGER NOT NULL REFERENCES runs(id),
+            timestamp TEXT NOT NULL,
+            event_type TEXT NOT NULL,
+            detail TEXT
         )
     """)
     if rows:
         conn.executemany(
-            "INSERT INTO runs (id, repo, issue_number, session_type, started_at, ended_at, outcome, pr_number, notes) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "INSERT INTO runs (id, repo, issue_number, session_type, started_at, ended_at, outcome, pr_number, notes, validation_reason) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
             rows,
+        )
+    if events:
+        conn.executemany(
+            "INSERT INTO run_events (run_id, timestamp, event_type, detail) VALUES (?, ?, ?, ?)",
+            events,
         )
     conn.commit()
     conn.close()
@@ -37,9 +54,9 @@ def _create_db(tmp_path: Path, rows: list[tuple] | None = None) -> Path:
 @pytest.mark.asyncio
 async def test_collect_returns_runs_sorted_newest_first(tmp_path):
     rows = [
-        (1, "owner/repo-a", 10, "planning", "2026-03-18T08:00:00Z", "2026-03-18T08:30:00Z", "completed", None, None),
-        (2, "owner/repo-b", 20, "implementation", "2026-03-19T10:00:00Z", "2026-03-19T11:00:00Z", "completed", 5, None),
-        (3, "owner/repo-a", 15, "planning", "2026-03-20T12:00:00Z", "2026-03-20T12:20:00Z", "failed", None, "error"),
+        (1, "owner/repo-a", 10, "planning", "2026-03-18T08:00:00Z", "2026-03-18T08:30:00Z", "completed", None, None, None),
+        (2, "owner/repo-b", 20, "implementation", "2026-03-19T10:00:00Z", "2026-03-19T11:00:00Z", "completed", 5, None, None),
+        (3, "owner/repo-a", 15, "planning", "2026-03-20T12:00:00Z", "2026-03-20T12:20:00Z", "failed", None, "error", None),
     ]
     db_path = _create_db(tmp_path, rows)
     result = await collect(db_path=str(db_path))
@@ -54,7 +71,7 @@ async def test_collect_returns_runs_sorted_newest_first(tmp_path):
 @pytest.mark.asyncio
 async def test_collect_limits_to_20_runs(tmp_path):
     rows = [
-        (i, "owner/repo", i, "planning", f"2026-03-{i:02d}T10:00:00Z", f"2026-03-{i:02d}T10:30:00Z", "completed", None, None)
+        (i, "owner/repo", i, "planning", f"2026-03-{i:02d}T10:00:00Z", f"2026-03-{i:02d}T10:30:00Z", "completed", None, None, None)
         for i in range(1, 26)
     ]
     db_path = _create_db(tmp_path, rows)
@@ -68,7 +85,7 @@ async def test_collect_limits_to_20_runs(tmp_path):
 @pytest.mark.asyncio
 async def test_collect_run_fields(tmp_path):
     rows = [
-        (1, "saabendtsen/ai-scheduler", 42, "implementation", "2026-03-19T10:00:00Z", "2026-03-19T11:00:00Z", "completed", 7, "some notes"),
+        (1, "saabendtsen/ai-scheduler", 42, "implementation", "2026-03-19T10:00:00Z", "2026-03-19T11:00:00Z", "completed", 7, "some notes", None),
     ]
     db_path = _create_db(tmp_path, rows)
     result = await collect(db_path=str(db_path))
@@ -91,7 +108,7 @@ async def test_collect_run_fields(tmp_path):
 @pytest.mark.asyncio
 async def test_health_completed_is_healthy(tmp_path):
     rows = [
-        (1, "owner/repo", 1, "planning", "2026-03-20T10:00:00Z", "2026-03-20T10:30:00Z", "completed", None, None),
+        (1, "owner/repo", 1, "planning", "2026-03-20T10:00:00Z", "2026-03-20T10:30:00Z", "completed", None, None, None),
     ]
     db_path = _create_db(tmp_path, rows)
     result = await collect(db_path=str(db_path))
@@ -101,7 +118,7 @@ async def test_health_completed_is_healthy(tmp_path):
 @pytest.mark.asyncio
 async def test_health_failed_is_unhealthy(tmp_path):
     rows = [
-        (1, "owner/repo", 1, "planning", "2026-03-20T10:00:00Z", "2026-03-20T10:30:00Z", "failed", None, None),
+        (1, "owner/repo", 1, "planning", "2026-03-20T10:00:00Z", "2026-03-20T10:30:00Z", "failed", None, None, None),
     ]
     db_path = _create_db(tmp_path, rows)
     result = await collect(db_path=str(db_path))
@@ -112,7 +129,7 @@ async def test_health_failed_is_unhealthy(tmp_path):
 @pytest.mark.parametrize("outcome", ["clarification", "timeout", "running"])
 async def test_health_warning_outcomes(tmp_path, outcome):
     rows = [
-        (1, "owner/repo", 1, "planning", "2026-03-20T10:00:00Z", "2026-03-20T10:30:00Z", outcome, None, None),
+        (1, "owner/repo", 1, "planning", "2026-03-20T10:00:00Z", "2026-03-20T10:30:00Z", outcome, None, None, None),
     ]
     db_path = _create_db(tmp_path, rows)
     result = await collect(db_path=str(db_path))
@@ -131,8 +148,8 @@ async def test_health_empty_db_is_unknown(tmp_path):
 async def test_health_uses_latest_run_only(tmp_path):
     """Health should be based on the most recent run, not older ones."""
     rows = [
-        (1, "owner/repo", 1, "planning", "2026-03-18T10:00:00Z", "2026-03-18T10:30:00Z", "completed", None, None),
-        (2, "owner/repo", 2, "implementation", "2026-03-20T10:00:00Z", "2026-03-20T10:30:00Z", "failed", None, None),
+        (1, "owner/repo", 1, "planning", "2026-03-18T10:00:00Z", "2026-03-18T10:30:00Z", "completed", None, None, None),
+        (2, "owner/repo", 2, "implementation", "2026-03-20T10:00:00Z", "2026-03-20T10:30:00Z", "failed", None, None, None),
     ]
     db_path = _create_db(tmp_path, rows)
     result = await collect(db_path=str(db_path))
@@ -146,7 +163,7 @@ async def test_health_uses_latest_run_only(tmp_path):
 async def test_db_file_not_modified(tmp_path):
     """Collector must not modify the DB file (read-only mode)."""
     rows = [
-        (1, "owner/repo", 1, "planning", "2026-03-20T10:00:00Z", "2026-03-20T10:30:00Z", "completed", None, None),
+        (1, "owner/repo", 1, "planning", "2026-03-20T10:00:00Z", "2026-03-20T10:30:00Z", "completed", None, None, None),
     ]
     db_path = _create_db(tmp_path, rows)
 
@@ -170,3 +187,26 @@ async def test_missing_db_returns_unknown(tmp_path):
     result = await collect(db_path=db_path)
     assert result["health"] == "unknown"
     assert result["runs"] == []
+
+
+# --- validation_reason ---
+
+
+@pytest.mark.asyncio
+async def test_collect_includes_validation_reason(tmp_path):
+    rows = [
+        (1, "owner/repo", 10, "implementation", "2026-03-20T10:00:00Z", "2026-03-20T10:30:00Z", "completed", 5, None, "PR #5 open, checks passed"),
+    ]
+    db_path = _create_db(tmp_path, rows)
+    result = await collect(db_path=str(db_path))
+    assert result["runs"][0]["validation_reason"] == "PR #5 open, checks passed"
+
+
+@pytest.mark.asyncio
+async def test_collect_validation_reason_null(tmp_path):
+    rows = [
+        (1, "owner/repo", 10, "planning", "2026-03-20T10:00:00Z", "2026-03-20T10:30:00Z", "completed", None, None, None),
+    ]
+    db_path = _create_db(tmp_path, rows)
+    result = await collect(db_path=str(db_path))
+    assert result["runs"][0]["validation_reason"] is None

--- a/backend/tests/test_scheduler_collector.py
+++ b/backend/tests/test_scheduler_collector.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from app.collectors.scheduler_collector import collect
+from app.collectors.scheduler_collector import collect, get_run_messages
 
 
 def _create_db(tmp_path: Path, rows: list[tuple] | None = None, events: list[tuple] | None = None) -> Path:
@@ -247,3 +247,67 @@ async def test_collect_run_with_no_events_gets_empty_array(tmp_path):
     db_path = _create_db(tmp_path, rows)  # no events
     result = await collect(db_path=str(db_path))
     assert result["runs"][0]["events"] == []
+
+
+# --- get_run_messages ---
+
+
+@pytest.mark.asyncio
+async def test_get_run_messages_returns_json(tmp_path):
+    messages_json = '[{"role": "user", "content": "hello"}]'
+    conn = sqlite3.connect(str(tmp_path / "history.db"))
+    conn.execute("""
+        CREATE TABLE runs (
+            id INTEGER PRIMARY KEY, repo TEXT, issue_number INTEGER,
+            session_type TEXT, started_at TEXT, ended_at TEXT,
+            outcome TEXT, pr_number INTEGER, notes TEXT,
+            validation_reason TEXT, messages TEXT
+        )
+    """)
+    conn.execute(
+        "INSERT INTO runs (id, repo, issue_number, session_type, started_at, ended_at, outcome, messages) "
+        "VALUES (1, 'o/r', 1, 'planning', '2026-01-01', '2026-01-01', 'completed', ?)",
+        (messages_json,),
+    )
+    conn.commit()
+    conn.close()
+    result = await get_run_messages(1, str(tmp_path / "history.db"))
+    assert result == [{"role": "user", "content": "hello"}]
+
+
+@pytest.mark.asyncio
+async def test_get_run_messages_null_returns_none(tmp_path):
+    conn = sqlite3.connect(str(tmp_path / "history.db"))
+    conn.execute("""
+        CREATE TABLE runs (
+            id INTEGER PRIMARY KEY, repo TEXT, issue_number INTEGER,
+            session_type TEXT, started_at TEXT, ended_at TEXT,
+            outcome TEXT, pr_number INTEGER, notes TEXT,
+            validation_reason TEXT, messages TEXT
+        )
+    """)
+    conn.execute(
+        "INSERT INTO runs (id, repo, issue_number, session_type, started_at, ended_at, outcome) "
+        "VALUES (1, 'o/r', 1, 'planning', '2026-01-01', '2026-01-01', 'completed')",
+    )
+    conn.commit()
+    conn.close()
+    result = await get_run_messages(1, str(tmp_path / "history.db"))
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_run_messages_not_found_raises(tmp_path):
+    conn = sqlite3.connect(str(tmp_path / "history.db"))
+    conn.execute("""
+        CREATE TABLE runs (
+            id INTEGER PRIMARY KEY, repo TEXT, issue_number INTEGER,
+            session_type TEXT, started_at TEXT, ended_at TEXT,
+            outcome TEXT, pr_number INTEGER, notes TEXT,
+            validation_reason TEXT, messages TEXT
+        )
+    """)
+    conn.commit()
+    conn.close()
+    with pytest.raises(ValueError):
+        await get_run_messages(999, str(tmp_path / "history.db"))

--- a/frontend/e2e/dashboard.spec.ts
+++ b/frontend/e2e/dashboard.spec.ts
@@ -48,6 +48,11 @@ const MOCK_STATUS = {
         outcome: 'completed',
         pr_number: null,
         notes: null,
+        validation_reason: 'Plan file found in comments',
+        events: [
+          { id: 1, timestamp: '2026-03-20T10:20:03Z', event_type: 'session_started', detail: null },
+          { id: 2, timestamp: '2026-03-20T10:22:31Z', event_type: 'session_completed', detail: '{"outcome": "completed"}' },
+        ],
       },
       {
         id: 88,
@@ -59,6 +64,8 @@ const MOCK_STATUS = {
         outcome: 'failed',
         pr_number: 12,
         notes: null,
+        validation_reason: 'No PR found for issue',
+        events: [],
       },
     ],
   },
@@ -244,6 +251,61 @@ test('refresh button triggers POST /api/refresh and updates data', async ({ page
 
   // After refresh, data should update
   await expect(page.getByTestId('cpu-value')).toHaveText('99.9%')
+})
+
+test('AI Scheduler tab shows validation reason and expandable events', async ({ page }) => {
+  await page.goto('/server-dashboard/')
+  await page.getByRole('tab', { name: 'AI Scheduler' }).click()
+
+  // Validation reason visible
+  await expect(page.getByText('Plan file found in comments')).toBeVisible()
+  await expect(page.getByText('No PR found for issue')).toBeVisible()
+
+  // Events toggle on first run (has events)
+  const firstRun = page.getByTestId('scheduler-run').nth(0)
+  const eventsToggle = firstRun.getByTestId('toggle-events')
+  await expect(eventsToggle).toBeVisible()
+  await expect(eventsToggle).toHaveText('Events (2)')
+
+  // Expand events
+  await eventsToggle.click()
+  await expect(firstRun.getByText('Session started')).toBeVisible()
+  await expect(firstRun.getByText(/Session completed/)).toBeVisible()
+
+  // Collapse events
+  await eventsToggle.click()
+  await expect(firstRun.getByText('Session started')).not.toBeVisible()
+
+  // Second run has no events — no toggle
+  const secondRun = page.getByTestId('scheduler-run').nth(1)
+  await expect(secondRun.locator('[data-testid="toggle-events"]')).toHaveCount(0)
+})
+
+test('AI Scheduler tab view messages button opens modal', async ({ page }) => {
+  // Mock the messages endpoint
+  await page.route('**/api/runs/89/messages', (route) =>
+    route.fulfill({
+      json: [
+        { role: 'user', content: 'Plan this feature' },
+        { role: 'assistant', content: 'I will create a plan' },
+      ],
+    })
+  )
+
+  await page.goto('/server-dashboard/')
+  await page.getByRole('tab', { name: 'AI Scheduler' }).click()
+
+  // Click view messages on first run
+  const firstRun = page.getByTestId('scheduler-run').nth(0)
+  await firstRun.getByTestId('view-messages').click()
+
+  // Modal should open with messages
+  await expect(page.getByText('Plan this feature')).toBeVisible()
+  await expect(page.getByText('I will create a plan')).toBeVisible()
+
+  // Close modal
+  await page.getByTestId('close-modal').click()
+  await expect(page.getByText('Plan this feature')).not.toBeVisible()
 })
 
 test('refresh button shows spinner while refreshing', async ({ page }) => {

--- a/frontend/src/components/shared/MessagesModal.test.tsx
+++ b/frontend/src/components/shared/MessagesModal.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import { MessagesModal } from './MessagesModal'
+
+describe('MessagesModal', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('shows loading state while fetching', () => {
+    vi.spyOn(global, 'fetch').mockImplementation(() => new Promise(() => {})) // never resolves
+    render(<MessagesModal runId={1} onClose={() => {}} />)
+    expect(screen.getByTestId('messages-loading')).toBeInTheDocument()
+  })
+
+  it('renders conversation messages', async () => {
+    const messages = [
+      { role: 'user', content: 'Fix the bug' },
+      { role: 'assistant', content: 'I will fix it now' },
+    ]
+    vi.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(messages),
+    } as Response)
+
+    render(<MessagesModal runId={1} onClose={() => {}} />)
+    await waitFor(() => {
+      expect(screen.getByText('Fix the bug')).toBeInTheDocument()
+      expect(screen.getByText('I will fix it now')).toBeInTheDocument()
+    })
+  })
+
+  it('shows expired notice on 204', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 204,
+      json: () => Promise.reject(),
+    } as Response)
+
+    render(<MessagesModal runId={1} onClose={() => {}} />)
+    await waitFor(() => {
+      expect(screen.getByText(/expired/i)).toBeInTheDocument()
+    })
+  })
+
+  it('calls onClose when close button clicked', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve([]),
+    } as Response)
+
+    const onClose = vi.fn()
+    render(<MessagesModal runId={1} onClose={onClose} />)
+    await waitFor(() => screen.getByTestId('close-modal'))
+    fireEvent.click(screen.getByTestId('close-modal'))
+    expect(onClose).toHaveBeenCalled()
+  })
+})

--- a/frontend/src/components/shared/MessagesModal.tsx
+++ b/frontend/src/components/shared/MessagesModal.tsx
@@ -1,0 +1,77 @@
+import { useEffect, useState } from 'react'
+import type { AgentMessage } from '../../types'
+
+interface Props {
+  runId: number
+  onClose: () => void
+}
+
+export function MessagesModal({ runId, onClose }: Props) {
+  const [messages, setMessages] = useState<AgentMessage[] | null>(null)
+  const [expired, setExpired] = useState(false)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    fetch(`/server-dashboard/api/runs/${runId}/messages`)
+      .then(res => {
+        if (res.status === 204) {
+          setExpired(true)
+          return null
+        }
+        if (!res.ok) throw new Error(`HTTP ${res.status}`)
+        return res.json()
+      })
+      .then(data => {
+        if (data !== null) setMessages(data)
+      })
+      .catch(err => setError(err.message))
+      .finally(() => setLoading(false))
+  }, [runId])
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={onClose}>
+      <div
+        className="bg-white dark:bg-gray-800 rounded-xl shadow-xl w-full max-w-2xl max-h-[80vh] flex flex-col m-4"
+        onClick={e => e.stopPropagation()}
+      >
+        <div className="flex justify-between items-center p-4 border-b border-gray-200 dark:border-gray-700">
+          <h3 className="text-sm font-semibold text-gray-900 dark:text-white">Agent Messages — Run #{runId}</h3>
+          <button data-testid="close-modal" onClick={onClose} className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 text-lg">
+            &times;
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto p-4 space-y-3">
+          {loading && (
+            <div data-testid="messages-loading" className="text-center text-gray-400 py-8">Loading messages...</div>
+          )}
+
+          {expired && (
+            <div className="text-center text-gray-400 py-8">Messages expired (retention cleanup)</div>
+          )}
+
+          {error && (
+            <div className="text-center text-red-400 py-8">Failed to load messages: {error}</div>
+          )}
+
+          {messages && messages.map((msg, i) => (
+            <div
+              key={i}
+              className={`rounded-lg p-3 text-sm ${
+                msg.role === 'assistant'
+                  ? 'bg-blue-50 dark:bg-blue-900/20 text-gray-900 dark:text-gray-100'
+                  : msg.role === 'user'
+                  ? 'bg-gray-100 dark:bg-gray-700 text-gray-900 dark:text-gray-100'
+                  : 'bg-yellow-50 dark:bg-yellow-900/20 text-gray-700 dark:text-gray-300 text-xs'
+              }`}
+            >
+              <span className="text-xs font-medium text-gray-500 dark:text-gray-400 block mb-1">{msg.role}</span>
+              <p className="whitespace-pre-wrap">{msg.content}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/shared/RunEventTimeline.test.tsx
+++ b/frontend/src/components/shared/RunEventTimeline.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { RunEventTimeline } from './RunEventTimeline'
+import type { RunEvent } from '../../types'
+
+const events: RunEvent[] = [
+  { id: 1, timestamp: '2026-03-20T10:00:00Z', event_type: 'session_started', detail: '{"session_id": "abc"}' },
+  { id: 2, timestamp: '2026-03-20T10:05:00Z', event_type: 'label_added', detail: '{"label": "ai-implementing"}' },
+  { id: 3, timestamp: '2026-03-20T10:15:00Z', event_type: 'pr_found', detail: '{"pr_number": 44}' },
+  { id: 4, timestamp: '2026-03-20T10:20:00Z', event_type: 'validation_checked', detail: '{"passed": true, "reason": "checks ok"}' },
+  { id: 5, timestamp: '2026-03-20T10:30:00Z', event_type: 'session_completed', detail: '{"outcome": "completed"}' },
+]
+
+describe('RunEventTimeline', () => {
+  it('renders all events', () => {
+    render(<RunEventTimeline events={events} />)
+    const items = screen.getAllByTestId('timeline-event')
+    expect(items).toHaveLength(5)
+  })
+
+  it('renders human-readable event descriptions', () => {
+    render(<RunEventTimeline events={events} />)
+    expect(screen.getByText('Session started')).toBeInTheDocument()
+    expect(screen.getByText(/ai-implementing/)).toBeInTheDocument()
+    expect(screen.getByText(/PR.*#44/)).toBeInTheDocument()
+    expect(screen.getByText(/Validation passed/)).toBeInTheDocument()
+    expect(screen.getByText(/Session completed/)).toBeInTheDocument()
+  })
+
+  it('renders empty state', () => {
+    const { container } = render(<RunEventTimeline events={[]} />)
+    expect(container.querySelector('[data-testid="timeline-event"]')).toBeNull()
+  })
+
+  it('handles unknown event types gracefully', () => {
+    const unknown: RunEvent[] = [
+      { id: 1, timestamp: '2026-03-20T10:00:00Z', event_type: 'new_future_event', detail: '{"key": "val"}' },
+    ]
+    render(<RunEventTimeline events={unknown} />)
+    expect(screen.getByText(/new_future_event/)).toBeInTheDocument()
+  })
+
+  it('handles null detail', () => {
+    const nullDetail: RunEvent[] = [
+      { id: 1, timestamp: '2026-03-20T10:00:00Z', event_type: 'session_started', detail: null },
+    ]
+    render(<RunEventTimeline events={nullDetail} />)
+    expect(screen.getByText('Session started')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/shared/RunEventTimeline.tsx
+++ b/frontend/src/components/shared/RunEventTimeline.tsx
@@ -1,0 +1,59 @@
+import type { RunEvent } from '../../types'
+import { formatTimestamp } from '../../utils/formatters'
+
+function formatEventDetail(event: RunEvent): string {
+  const { event_type, detail } = event
+  let parsed: Record<string, unknown> = {}
+  if (detail) {
+    try {
+      parsed = JSON.parse(detail)
+    } catch {
+      return `${event_type}: ${detail}`
+    }
+  }
+
+  switch (event_type) {
+    case 'session_started':
+      return 'Session started'
+    case 'session_completed':
+      return `Session completed${parsed.outcome ? `: ${parsed.outcome}` : ''}`
+    case 'label_added':
+      return `Label added: ${parsed.label ?? '?'}`
+    case 'label_removed':
+      return `Label removed: ${parsed.label ?? '?'}`
+    case 'pr_found':
+      return `PR found: #${parsed.pr_number ?? '?'}`
+    case 'validation_checked':
+      return parsed.passed ? 'Validation passed' : 'Validation failed'
+    case 'recheck_resolved':
+      return `Recheck resolved: ${parsed.resolution ?? '?'}`
+    default:
+      return detail ? `${event_type}: ${detail}` : event_type
+  }
+}
+
+const EVENT_COLORS: Record<string, string> = {
+  session_started: 'bg-blue-400',
+  session_completed: 'bg-green-400',
+  label_added: 'bg-purple-400',
+  label_removed: 'bg-gray-400',
+  pr_found: 'bg-blue-400',
+  validation_checked: 'bg-yellow-400',
+  recheck_resolved: 'bg-green-400',
+}
+
+export function RunEventTimeline({ events }: { events: RunEvent[] }) {
+  if (events.length === 0) return null
+
+  return (
+    <div className="relative ml-2 border-l-2 border-gray-200 dark:border-gray-600 pl-4 space-y-3 mt-3">
+      {events.map((event) => (
+        <div key={event.id} data-testid="timeline-event" className="relative">
+          <div className={`absolute -left-[1.35rem] top-1 w-2.5 h-2.5 rounded-full ${EVENT_COLORS[event.event_type] || 'bg-gray-400'}`} />
+          <p className="text-xs text-gray-900 dark:text-gray-100">{formatEventDetail(event)}</p>
+          <p className="text-xs text-gray-400 dark:text-gray-500">{formatTimestamp(event.timestamp)}</p>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/frontend/src/components/tabs/SchedulerTab.test.tsx
+++ b/frontend/src/components/tabs/SchedulerTab.test.tsx
@@ -16,6 +16,8 @@ const fixture: SchedulerData = {
       outcome: 'completed',
       pr_number: 15,
       notes: null,
+      validation_reason: 'PR #15 open, checks passed',
+      events: [],
     },
   ],
 }
@@ -45,5 +47,19 @@ describe('SchedulerTab', () => {
     render(<SchedulerTab scheduler={fixture} />)
     expect(screen.getByText('#42')).toBeInTheDocument()
     expect(screen.getByText('#15')).toBeInTheDocument()
+  })
+
+  it('renders validation reason when present', () => {
+    render(<SchedulerTab scheduler={fixture} />)
+    expect(screen.getByText('PR #15 open, checks passed')).toBeInTheDocument()
+  })
+
+  it('does not render validation reason when null', () => {
+    const noReason = {
+      ...fixture,
+      runs: [{ ...fixture.runs[0], validation_reason: null }],
+    }
+    render(<SchedulerTab scheduler={noReason} />)
+    expect(screen.queryByTestId('validation-reason')).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/components/tabs/SchedulerTab.test.tsx
+++ b/frontend/src/components/tabs/SchedulerTab.test.tsx
@@ -87,4 +87,11 @@ describe('SchedulerTab', () => {
     render(<SchedulerTab scheduler={fixture} />) // fixture has events: []
     expect(screen.queryByTestId('toggle-events')).not.toBeInTheDocument()
   })
+
+  it('opens messages modal when view messages button is clicked', () => {
+    vi.spyOn(global, 'fetch').mockImplementation(() => new Promise(() => {}))
+    render(<SchedulerTab scheduler={fixture} />)
+    fireEvent.click(screen.getByTestId('view-messages'))
+    expect(screen.getByTestId('messages-loading')).toBeInTheDocument()
+  })
 })

--- a/frontend/src/components/tabs/SchedulerTab.test.tsx
+++ b/frontend/src/components/tabs/SchedulerTab.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { SchedulerTab } from './SchedulerTab'
 import type { SchedulerData } from '../../types'
 
@@ -61,5 +61,30 @@ describe('SchedulerTab', () => {
     }
     render(<SchedulerTab scheduler={noReason} />)
     expect(screen.queryByTestId('validation-reason')).not.toBeInTheDocument()
+  })
+
+  it('shows event timeline when events button is clicked', () => {
+    const fixtureWithEvents: SchedulerData = {
+      health: 'healthy',
+      runs: [
+        {
+          ...fixture.runs[0],
+          events: [
+            { id: 1, timestamp: '2026-03-20T10:00:00Z', event_type: 'session_started', detail: null },
+            { id: 2, timestamp: '2026-03-20T10:30:00Z', event_type: 'session_completed', detail: '{"outcome": "completed"}' },
+          ],
+        },
+      ],
+    }
+    render(<SchedulerTab scheduler={fixtureWithEvents} />)
+    expect(screen.queryByTestId('timeline-event')).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('toggle-events'))
+    expect(screen.getAllByTestId('timeline-event')).toHaveLength(2)
+  })
+
+  it('hides events button when run has no events', () => {
+    render(<SchedulerTab scheduler={fixture} />) // fixture has events: []
+    expect(screen.queryByTestId('toggle-events')).not.toBeInTheDocument()
   })
 })

--- a/frontend/src/components/tabs/SchedulerTab.tsx
+++ b/frontend/src/components/tabs/SchedulerTab.tsx
@@ -44,7 +44,14 @@ export function SchedulerTab({ scheduler }: { scheduler: SchedulerData }) {
                     </a>
                   )}
                 </div>
-                <OutcomeBadge outcome={run.outcome} />
+                <div className="flex flex-col items-end gap-1">
+                  <OutcomeBadge outcome={run.outcome} />
+                  {run.validation_reason && (
+                    <span data-testid="validation-reason" className="text-xs text-gray-500 dark:text-gray-400">
+                      {run.validation_reason}
+                    </span>
+                  )}
+                </div>
               </div>
               <div className="flex justify-between items-center">
                 <span className="text-xs text-gray-500 dark:text-gray-400">{run.session_type}</span>

--- a/frontend/src/components/tabs/SchedulerTab.tsx
+++ b/frontend/src/components/tabs/SchedulerTab.tsx
@@ -1,9 +1,22 @@
+import { useState } from 'react'
 import type { SchedulerData } from '../../types'
 import { formatTimestamp, repoShortName } from '../../utils/formatters'
 import { OutcomeBadge } from '../shared/OutcomeBadge'
+import { RunEventTimeline } from '../shared/RunEventTimeline'
 import { SchedulerHealthBadge } from '../shared/SchedulerHealthBadge'
 
 export function SchedulerTab({ scheduler }: { scheduler: SchedulerData }) {
+  const [expandedRuns, setExpandedRuns] = useState<Set<number>>(new Set())
+
+  const toggleExpand = (runId: number) => {
+    setExpandedRuns(prev => {
+      const next = new Set(prev)
+      if (next.has(runId)) next.delete(runId)
+      else next.add(runId)
+      return next
+    })
+  }
+
   return (
     <div className="space-y-4">
       <div className="bg-white dark:bg-gray-800 rounded-xl p-4 shadow-sm border border-gray-100 dark:border-gray-700">
@@ -60,6 +73,18 @@ export function SchedulerTab({ scheduler }: { scheduler: SchedulerData }) {
                   {run.ended_at && ` - ${formatTimestamp(run.ended_at)}`}
                 </span>
               </div>
+              {run.events.length > 0 && (
+                <>
+                  <button
+                    data-testid="toggle-events"
+                    onClick={() => toggleExpand(run.id)}
+                    className="text-xs text-primary hover:underline mt-2"
+                  >
+                    {expandedRuns.has(run.id) ? 'Hide events' : `Events (${run.events.length})`}
+                  </button>
+                  {expandedRuns.has(run.id) && <RunEventTimeline events={run.events} />}
+                </>
+              )}
             </div>
           ))}
         </div>

--- a/frontend/src/components/tabs/SchedulerTab.tsx
+++ b/frontend/src/components/tabs/SchedulerTab.tsx
@@ -1,12 +1,14 @@
 import { useState } from 'react'
 import type { SchedulerData } from '../../types'
 import { formatTimestamp, repoShortName } from '../../utils/formatters'
+import { MessagesModal } from '../shared/MessagesModal'
 import { OutcomeBadge } from '../shared/OutcomeBadge'
 import { RunEventTimeline } from '../shared/RunEventTimeline'
 import { SchedulerHealthBadge } from '../shared/SchedulerHealthBadge'
 
 export function SchedulerTab({ scheduler }: { scheduler: SchedulerData }) {
   const [expandedRuns, setExpandedRuns] = useState<Set<number>>(new Set())
+  const [messagesRunId, setMessagesRunId] = useState<number | null>(null)
 
   const toggleExpand = (runId: number) => {
     setExpandedRuns(prev => {
@@ -73,21 +75,34 @@ export function SchedulerTab({ scheduler }: { scheduler: SchedulerData }) {
                   {run.ended_at && ` - ${formatTimestamp(run.ended_at)}`}
                 </span>
               </div>
-              {run.events.length > 0 && (
-                <>
-                  <button
-                    data-testid="toggle-events"
-                    onClick={() => toggleExpand(run.id)}
-                    className="text-xs text-primary hover:underline mt-2"
-                  >
-                    {expandedRuns.has(run.id) ? 'Hide events' : `Events (${run.events.length})`}
-                  </button>
-                  {expandedRuns.has(run.id) && <RunEventTimeline events={run.events} />}
-                </>
-              )}
+              <div className="flex gap-2 mt-2">
+                {run.events.length > 0 && (
+                  <>
+                    <button
+                      data-testid="toggle-events"
+                      onClick={() => toggleExpand(run.id)}
+                      className="text-xs text-primary hover:underline"
+                    >
+                      {expandedRuns.has(run.id) ? 'Hide events' : `Events (${run.events.length})`}
+                    </button>
+                  </>
+                )}
+                <button
+                  data-testid="view-messages"
+                  onClick={() => setMessagesRunId(run.id)}
+                  className="text-xs text-primary hover:underline"
+                >
+                  View messages
+                </button>
+              </div>
+              {expandedRuns.has(run.id) && run.events.length > 0 && <RunEventTimeline events={run.events} />}
             </div>
           ))}
         </div>
+      )}
+
+      {messagesRunId !== null && (
+        <MessagesModal runId={messagesRunId} onClose={() => setMessagesRunId(null)} />
       )}
     </div>
   )

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -32,6 +32,18 @@ export interface ServiceData {
   healthcheck: HealthcheckResult | null
 }
 
+export interface RunEvent {
+  id: number
+  timestamp: string
+  event_type: string
+  detail: string | null
+}
+
+export interface AgentMessage {
+  role: string
+  content: string
+}
+
 export interface SchedulerRun {
   id: number
   repo: string
@@ -42,6 +54,8 @@ export interface SchedulerRun {
   outcome: string
   pr_number: number | null
   notes: string | null
+  validation_reason: string | null
+  events: RunEvent[]
 }
 
 export interface SchedulerData {

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -24,5 +24,6 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.tsx", "src/**/*.test.ts"]
 }


### PR DESCRIPTION
## Summary

- Add `validation_reason` field to scheduler collector SQL query and display it on run cards
- Add `run_events` nested per run with expandable timeline component (color-coded event dots, human-readable descriptions)
- Add `/api/runs/{id}/messages` endpoint + MessagesModal for on-demand agent message viewing (with loading, expired, error states)
- Update all TypeScript types (`RunEvent`, `AgentMessage`, `SchedulerRun`)

## Test Plan

- [x] Backend: 64 tests pass (collector, messages endpoint, API fixtures)
- [x] Frontend unit: 46 tests pass (SchedulerTab, RunEventTimeline, MessagesModal)
- [x] E2E: 10 Playwright tests pass (validation_reason, event timeline expand/collapse, messages modal)

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)