### PR TITLE
Add README, license and security policy for public review

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Søren Aabendtsen
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,98 @@
+# server-dashboard
+
+A single-page monitoring dashboard for one small home server. A FastAPI backend
+polls a handful of local data sources every 15 minutes and serves a React SPA
+with four tabs: **Server Overview** (disk, CPU, temperature, load, memory,
+uptime), **AI Scheduler** (runs, events and agent messages read from the
+scheduler's SQLite history), **GitHub Actions** (recent workflow runs of the
+maintainer's repositories) and **Services** (Docker containers with optional
+HTTP health checks).
+
+## Status
+
+Personal, experimental homelab tool. It is tailored to the maintainer's own
+server layout and is published as-is for reference; it is not a general-purpose
+product, has no releases and is maintained occasionally. Breaking changes can
+land on `main` at any time.
+
+## How it works
+
+- `backend/app/main.py` exposes `GET /health`, `GET /api/status` (all cached
+  collector output), `POST /api/refresh` (immediate re-poll) and
+  `GET /api/runs/{run_id}/messages`, and serves the built frontend from
+  `backend/static/`.
+- `backend/app/collectors/` holds one independent collector per data source
+  (`system.py` via psutil, `docker_collector.py` via the Docker socket,
+  `github_collector.py` via the `gh` CLI, `scheduler_collector.py` via
+  aiosqlite, `health_checker.py` for labelled containers). A failing collector
+  never blocks the others; `cache.py` holds the latest results in memory.
+- `frontend/` is a Vite + React 19 + Tailwind CSS 4 SPA with Playwright E2E tests.
+- `plans/` and `docs/superpowers/` are the design documents the code was built
+  from; they describe intent and may lag the implementation.
+
+## Setup
+
+Backend (Python 3.12):
+
+```sh
+cd backend
+python -m venv .venv && . .venv/bin/activate
+pip install -r requirements-dev.txt
+pytest
+uvicorn app.main:app --reload --port 8000
+```
+
+Frontend (Node.js 20+):
+
+```sh
+cd frontend
+npm ci
+npm run dev          # Vite dev server
+npm run lint
+npm run build        # output in frontend/dist, copied to backend/static by the Dockerfile
+npx playwright test  # E2E tests against a running backend
+```
+
+Container:
+
+```sh
+docker compose up --build   # http://localhost:8070
+```
+
+Configuration is by environment variable:
+
+| Variable | Purpose | Default |
+| --- | --- | --- |
+| `GITHUB_TOKEN` | token the `gh` CLI uses to list repositories and workflow runs | unset → GitHub tab is empty |
+| `SCHEDULER_DB_PATH` | path to the AI Scheduler SQLite history, opened read-only | `~/apps/ai-scheduler/history.db` |
+
+Containers opt into HTTP health checks with the Docker label
+`dashboard.healthcheck.url`. The compose file mounts `/var/run/docker.sock`
+read-only so the Services tab can list containers.
+
+## Data and privacy
+
+The dashboard reads host metrics, container metadata, the scheduler database and
+GitHub workflow metadata and shows them unauthenticated on whatever network it
+is exposed to. It stores nothing of its own and has no user accounts, but
+**everything it displays about the host is visible to anyone who can reach it**,
+so put it behind a reverse proxy with access control or keep it on a private
+network. The `GITHUB_TOKEN` is read from the environment and never logged or
+returned by the API.
+
+The repository itself contains no credentials or personal data; the design
+documents mention the maintainer's own hostnames and paths only generically.
+
+## Third-party material
+
+Dependencies are published under permissive licences: FastAPI, aiosqlite, React
+and the Vite/Tailwind toolchain (MIT), uvicorn, psutil and httpx (BSD-3-Clause),
+docker-py (Apache-2.0). No fonts, images or data sets are vendored.
+
+## Security
+
+See [SECURITY.md](SECURITY.md) for how to report a vulnerability.
+
+## License
+
+[MIT](LICENSE) © 2026 Søren Aabendtsen.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,18 @@
+# Security policy
+
+## Supported versions
+
+Only the current `main` branch is maintained. There are no versioned releases.
+
+## Reporting a vulnerability
+
+Please do not open a public issue for security problems.
+
+Use GitHub's private vulnerability reporting on this repository
+(**Security → Report a vulnerability**) or contact the maintainer through the
+GitHub profile [@saabendtsen](https://github.com/saabendtsen). You should get a
+first response within 14 days. Please include steps to reproduce and the commit
+or deployment you tested against.
+
+This is a personal homelab tool. Fixes are made on a best-effort basis and there is no
+bug bounty.


### PR DESCRIPTION
Remediates the criterion 3/8 findings of the 2026-08-19 public-release audit recorded in saabendtsen/homelab-workspace (inventories/public-release/saabendtsen--server-dashboard-2026-08-19.json), for saabendtsen/homelab-workspace#83.

- MIT LICENSE
- SECURITY.md with private vulnerability reporting
- README: purpose, status, setup, configuration, data/privacy caveats, third-party material

Documentation only; no code change.